### PR TITLE
Fix path to include v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/asecurityteam/component-producer
+module github.com/asecurityteam/component-producer/v2
 
 go 1.15
 


### PR DESCRIPTION
https://golang.org/doc/modules/major-version requires changing path in go.mod, something I overlooked in my previous PR.